### PR TITLE
Fix thrift dependency for install

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "winston": "0.6.x",
     "commander": "1.1.x",
 
-    "thrift": "1.0.0-dev",
+    "node-thrift": "1.0.0-dev",
     "node-int64": "0.3.x"
   },
   "devDependencies": {


### PR DESCRIPTION
- specifically switched "thrift": "1.0.0-dev"
  to "node-thrift": "1.0.0-dev"
  the URL https://registry.npmjs.org/thrift/1.0.0-dev gets a 404
  while https://registry.npmjs.org/node-thrift/1.0.0-dev is available
